### PR TITLE
Add pytest asyncio, rename workflow

### DIFF
--- a/.github/workflows/ci-pytest.yml
+++ b/.github/workflows/ci-pytest.yml
@@ -1,7 +1,6 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+# This workflow will install Python dependencies, and run tests
 
-name: Python package
+name: Test Python package
 
 on:
   push:
@@ -11,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: Automated Test Suite
 
     runs-on: ubuntu-latest
 
@@ -23,8 +23,7 @@ jobs:
     - name: Install bot as package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
-        python -m pip install -e .
+        python -m pip install -e .[test]
     - name: Test with pytest
       run: |
         pytest


### PR DESCRIPTION
Adding `pytest-asyncio` to the test suite broke the CI, because none of the asyncio tests could run.

As a remedy, I've added an optional dependencies entry to `pyproject.toml`, which will install all testing dependencies.

Furthermore, the `build` status check name was too generic, I've changed it to `Automated Test Suite`. This is a more explicit name.
