### PR TITLE
time harmonization and restart message patch

### DIFF
--- a/comrade/core/bot_subclass.py
+++ b/comrade/core/bot_subclass.py
@@ -49,11 +49,21 @@ class Comrade(Client):
 
         if self.notify_on_restart:
             self.logger.info(
-                f"Notifying on restart: Channel with ID {self.notify_on_restart}"
+                f"Notifying on restart: Channel/User with ID {self.notify_on_restart}"
             )
-            await self.get_channel(self.notify_on_restart).send(
+
+            restart_msg = (
                 f"Bot has restarted, current version is {__version__}."
             )
+
+            if channel := self.get_channel(self.notify_on_restart):
+                await channel.send(restart_msg)
+            elif user := self.get_user(self.notify_on_restart):
+                await user.send(restart_msg)
+            else:
+                self.logger.warning(
+                    f"Could not find channel or user with ID {self.notify_on_restart}"
+                )
 
     @property
     def http_session(self) -> ClientSession:
@@ -67,4 +77,4 @@ class Comrade(Client):
         """
         if not (st := self._connection_state.start_time):
             return arrow.now(self.timezone)
-        return arrow.Arrow.fromdatetime(st)
+        return arrow.Arrow.fromdatetime(st, self.timezone)

--- a/comrade/modules/telemetry.py
+++ b/comrade/modules/telemetry.py
@@ -1,5 +1,6 @@
 from platform import python_version
 
+import arrow
 from interactions import Embed, Extension, File, SlashContext, slash_command
 from interactions.client.const import __version__ as __interactions_version__
 
@@ -20,8 +21,10 @@ class Telemetry(Extension):
         )
 
         embed.add_field(
-            name="Started",
-            value=self.bot.start_time.humanize(),
+            name="Uptime",
+            value=arrow.now(self.bot.timezone).humanize(
+                self.bot.start_time, only_distance=True
+            ),
             inline=True,
         )
 


### PR DESCRIPTION
# Time Harmonization
* bot.start_time is now in the proper timezone
* Status now uses arrow.humanize #12 

# Restart message
* wasn't working in DMs before, fixed now