### PR TITLE
QoL Cleanups and Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,9 +158,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-# version
-*_version.py
-
 # VS code
 .vscode/
 

--- a/comrade/__init__.py
+++ b/comrade/__init__.py
@@ -1,0 +1,7 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    # package is not installed
+    __version__ = "unknown"

--- a/comrade/bot.py
+++ b/comrade/bot.py
@@ -7,7 +7,7 @@ from interactions.client.const import CLIENT_FEATURE_FLAGS
 from interactions.ext import prefixed_commands
 
 from comrade.core.bot_subclass import Comrade
-from comrade.core.configuration import BOT_TOKEN, DEBUG
+from comrade.core.configuration import ACCENT_COLOUR, BOT_TOKEN, DEBUG
 from comrade.core.init_logging import init_logging
 
 
@@ -22,7 +22,6 @@ def main(token: str = None):
     )
     args = parser.parse_args()
 
-    # Load env vars, if needed
     if token is None:
         token = BOT_TOKEN
 
@@ -44,6 +43,11 @@ def main(token: str = None):
         if module.stem == "__init__":
             continue
         bot.load_extension(f"comrade.modules.{module.stem}")
+
+    help_cmd = prefixed_commands.help.PrefixedHelpCommand(
+        bot, embed_color=ACCENT_COLOUR
+    )
+    help_cmd.register()
 
     if DEBUG:
         bot.load_extension("interactions.ext.jurigged")

--- a/comrade/core/bot_subclass.py
+++ b/comrade/core/bot_subclass.py
@@ -1,3 +1,5 @@
+from zoneinfo import ZoneInfo
+
 import arrow
 import orjson
 from aiohttp import ClientSession
@@ -102,7 +104,12 @@ class Comrade(Client):
     def start_time(self) -> arrow.Arrow:
         """
         The start time of the bot, as an Arrow instance.
+
+        Timezone is set to the bot's timezone.
         """
         if not (st := self._connection_state.start_time):
             return arrow.now(self.timezone)
-        return arrow.Arrow.fromdatetime(st, "UTC")
+
+        # ensure that st is localized to our timezone (because it defaults to whatever
+        # the system timezone is)
+        return arrow.Arrow.fromdatetime(st.astimezone(ZoneInfo(self.timezone)))

--- a/comrade/core/bot_subclass.py
+++ b/comrade/core/bot_subclass.py
@@ -57,8 +57,11 @@ class Comrade(Client):
 
     @listen()
     async def on_login(self):
+        """
+        Hook onto the first even in the asyncio loop in order
+        to initialize the aiohttp ClientSession.
+        """
         self.http_session = ClientSession(json_serialize=orjson.dumps)
-        self.logger.info("Created HTTP session")
 
     @listen()
     async def on_ready(self):

--- a/comrade/core/bot_subclass.py
+++ b/comrade/core/bot_subclass.py
@@ -4,7 +4,7 @@ from interactions import MISSING, Client, listen
 from pymongo import MongoClient
 from pymongo.database import Database
 
-from comrade._version import __version__
+from comrade import __version__
 from comrade.core.configuration import DEBUG_SCOPE, MONGODB_URI, TIMEZONE
 from comrade.core.const import CLIENT_INIT_KWARGS
 

--- a/comrade/lib/discord_utils/__init__.py
+++ b/comrade/lib/discord_utils/__init__.py
@@ -1,3 +1,11 @@
-from .ctx_tricks import multi_ctx_dispatch
+from .ctx_tricks import ContextDict, context_id
 from .custom_paginators import DynamicPaginator
 from .webhook_tricks import echo, send_channel_webhook
+
+__all__ = [
+    "context_id",
+    "ContextDict",
+    "DynamicPaginator",
+    "echo",
+    "send_channel_webhook",
+]

--- a/comrade/lib/text_utils/__init__.py
+++ b/comrade/lib/text_utils/__init__.py
@@ -5,3 +5,13 @@ from .regional_indicator import (
     regional_indicator_to_txt,
     txt_to_regional_indicator,
 )
+
+__all__ = [
+    "emojify",
+    "mock",
+    "owoify",
+    "text_safe_length",
+    "escape_md",
+    "regional_indicator_to_txt",
+    "txt_to_regional_indicator",
+]

--- a/comrade/modules/maintainence.py
+++ b/comrade/modules/maintainence.py
@@ -3,6 +3,7 @@ from interactions.ext.prefixed_commands import PrefixedContext, prefixed_command
 
 from comrade import __version__
 from comrade.core.updater import pull_repo, restart_process, update_packages
+from comrade.lib.discord_utils import context_id
 from comrade.lib.updater_utils import (
     check_updates_on_branch,
     get_current_branch,
@@ -23,7 +24,7 @@ class Maintainence(Extension):
         """
         await ctx.send("Restarting...", ephemeral=True)
         self.bot.logger.warning("RESTARTING BOT!")
-        restart_process(ctx.channel_id)
+        restart_process(context_id(ctx))
 
     @slash_command(description="Checks for updates on this git branch")
     async def check_updates(self, ctx: SlashContext):
@@ -87,7 +88,7 @@ class Maintainence(Extension):
 
         await ctx.send("Restarting bot...", ephemeral=True)
         self.bot.logger.warning("RESTARTING BOT FOR NEW UPDATE...")
-        restart_process(ctx.channel_id)
+        restart_process(context_id(ctx))
 
 
 def setup(bot):

--- a/comrade/modules/maintainence.py
+++ b/comrade/modules/maintainence.py
@@ -1,4 +1,4 @@
-from interactions import Extension, SlashContext, check, is_owner, slash_command
+from interactions import Extension, SlashContext, check, is_owner
 from interactions.ext.prefixed_commands import PrefixedContext, prefixed_command
 
 from comrade import __version__
@@ -16,7 +16,7 @@ class Maintainence(Extension):
     Commands used for maintainence of the bot.
     """
 
-    @slash_command(description="Restarts the bot")
+    @prefixed_command(help="Restarts the bot")
     @check(is_owner())
     async def restart(self, ctx: SlashContext):
         """
@@ -26,7 +26,7 @@ class Maintainence(Extension):
         self.bot.logger.warning("RESTARTING BOT!")
         restart_process(context_id(ctx))
 
-    @slash_command(description="Checks for updates on this git branch")
+    @prefixed_command(help="Checks for updates on this git branch")
     async def check_updates(self, ctx: SlashContext):
         """
         Checks for updates on this git branch.

--- a/comrade/modules/maintainence.py
+++ b/comrade/modules/maintainence.py
@@ -1,7 +1,7 @@
 from interactions import Extension, SlashContext, check, is_owner, slash_command
 from interactions.ext.prefixed_commands import PrefixedContext, prefixed_command
 
-from comrade._version import __version__
+from comrade import __version__
 from comrade.core.updater import pull_repo, restart_process, update_packages
 from comrade.lib.updater_utils import (
     check_updates_on_branch,

--- a/comrade/modules/telemetry.py
+++ b/comrade/modules/telemetry.py
@@ -49,7 +49,7 @@ class Telemetry(Extension):
     @slash_command(
         description="Gets the log for the bot",
     )
-    async def view_log(self, ctx: SlashContext):
+    async def log(self, ctx: SlashContext):
         log_path = self.bot.logger.handlers[1].baseFilename
 
         log_file = File(log_path, file_name="comrade_log.txt")

--- a/comrade/modules/telemetry.py
+++ b/comrade/modules/telemetry.py
@@ -4,7 +4,7 @@ import arrow
 from interactions import Embed, Extension, File, SlashContext, slash_command
 from interactions.client.const import __version__ as __interactions_version__
 
-from comrade._version import __version_tuple__ as __comrade_version__
+from comrade import __version__ as __comrade_version__
 from comrade.core.bot_subclass import Comrade
 from comrade.core.configuration import ACCENT_COLOUR
 from comrade.lib.updater_utils import get_current_branch
@@ -33,7 +33,9 @@ class Telemetry(Extension):
             value=f"{self.bot.latency * 1000:.2f} ms",
             inline=True,
         )
-        comrade_version = ".".join(map(str, __comrade_version__[:4]))
+
+        # Drop the +... from the version
+        comrade_version = __comrade_version__.split("+")[0]
 
         embed.set_footer(
             text=f"Comrade v{comrade_version} on "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,6 @@ test = [
     "pytest-asyncio >= 0.21"
 ]
 
-[tool.setuptools_scm]
-write_to = "comrade/_version.py"
-
 [tool.setuptools]
 packages = ["comrade"]
 


### PR DESCRIPTION
# Changelog
* Changed `.http_session` to its own instance of ClientSession as prposed in #28 
* Fix #25 using the new `context_id` addition
* Fix #26 

# New additions -- `ctx_tricks`
* `context_id` -- used for when you need something similar to `BaseContext.channel_id`, but needs to work in DMs as well
    * Accessing `.channel_id` in DMs just results in returning the bot's user ID
* `ContextDict` dictionary whose keys are `BaseContext` instances, using `context_id` under the hood to hash