### PR TITLE
Revert dynamic versioning changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# version
+*_version.py
+
 # VS code
 .vscode/
 

--- a/comrade/__init__.py
+++ b/comrade/__init__.py
@@ -1,7 +1,0 @@
-from importlib.metadata import PackageNotFoundError, version
-
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
-    # package is not installed
-    __version__ = "unknown"

--- a/comrade/core/bot_subclass.py
+++ b/comrade/core/bot_subclass.py
@@ -7,7 +7,7 @@ from interactions import MISSING, Client, listen
 from pymongo import MongoClient
 from pymongo.database import Database
 
-from comrade import __version__
+from comrade._version import __version__
 from comrade.core.configuration import DEBUG_SCOPE, MONGODB_URI, TIMEZONE
 from comrade.core.const import CLIENT_INIT_KWARGS
 

--- a/comrade/modules/maintainence.py
+++ b/comrade/modules/maintainence.py
@@ -1,7 +1,7 @@
 from interactions import Extension, SlashContext, check, is_owner
 from interactions.ext.prefixed_commands import PrefixedContext, prefixed_command
 
-from comrade import __version__
+from comrade._version import __version__
 from comrade.core.updater import pull_repo, restart_process, update_packages
 from comrade.lib.discord_utils import context_id
 from comrade.lib.updater_utils import (

--- a/comrade/modules/telemetry.py
+++ b/comrade/modules/telemetry.py
@@ -4,7 +4,7 @@ import arrow
 from interactions import Embed, Extension, File, SlashContext, slash_command
 from interactions.client.const import __version__ as __interactions_version__
 
-from comrade import __version__ as __comrade_version__
+from comrade._version import __version__ as __comrade_version__
 from comrade.core.bot_subclass import Comrade
 from comrade.core.configuration import ACCENT_COLOUR
 from comrade.lib.updater_utils import get_current_branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ test = [
     "pytest-asyncio >= 0.21"
 ]
 
+[tool.setuptools_scm]
+write_to = "comrade/_version.py"
+
 [tool.setuptools]
 packages = ["comrade"]
 


### PR DESCRIPTION
The dynamic versioning changes implemented in #34 broke when the bot was running in a deploy key.