### PR TITLE
NH: Previous Page Button, Better Caching Logic

### DIFF
--- a/comrade/core/relay_system/relay_main.py
+++ b/comrade/core/relay_system/relay_main.py
@@ -199,13 +199,14 @@ class Relay(RelayCacheMixin):
             "filename": filename,
         }
 
-        # merge the base document with the additional data, with the additional data taking precedence
+        # merge the base document with the additional data, with the
+        # additional data taking precedence
         document = base_document | document_data
 
         # For safety, check if the document is already in the database
         try:
             mongodb_collection.insert_one(document)
-            # Cache the document (non-blocking)
+            # Cache the document
             self.cache_blob(document)
             return document
         except DuplicateKeyError:
@@ -323,7 +324,7 @@ class Relay(RelayCacheMixin):
 
         result = mongodb_collection.delete_one({"_id": source_url})
 
-        # Remove the document from the cache
+        # Remove the document from the local cache
         self.uncache_blob(source_url)
 
         if result.deleted_count == 0:

--- a/comrade/core/relay_system/utils.py
+++ b/comrade/core/relay_system/utils.py
@@ -15,4 +15,6 @@ def give_filename_extension(filename: str, data: bytes) -> str:
     if "." in filename:
         return filename
     else:
-        return filename + guess_extension(get_file_mimetype(data))
+        if not (ext := guess_extension(get_file_mimetype(data))):
+            ext = ""
+        return filename + ext

--- a/comrade/core/updater.py
+++ b/comrade/core/updater.py
@@ -41,14 +41,14 @@ def check_updates_on_branch() -> str:
     )
 
 
-def restart_process(notify_channel: int = None) -> None:
+def restart_process(notify_channel: int | None = None) -> None:
     """
     Restart the bot with all the same arguments it was launched with,
     except for the notify_channel argument.
 
     Parameters
     ----------
-    notify_channel : int
+    notify_channel : int | None
         The channel ID to send a message to after restarting;
         if None, no message will be sent.
     """

--- a/comrade/lib/discord_utils/custom_paginators.py
+++ b/comrade/lib/discord_utils/custom_paginators.py
@@ -29,7 +29,7 @@ class DynamicPaginator:
     message: Message
     current_page: int = 1
     custom_id_root: str
-    pages: dict[int, list[ActionRow]]
+    pages: dict[int, tuple[list[ActionRow], str]]
     uuid: str
 
     generate_page: Callable[[int], Awaitable[tuple[list[ActionRow], str]]]
@@ -179,7 +179,7 @@ class DynamicPaginator:
         """
         page_components, content = await self.get_page(self.current_page)
 
-        await ctx.send(
+        return await ctx.send(
             content=content, components=page_components + self.page_navigation
         )
 

--- a/comrade/lib/discord_utils/webhook_tricks.py
+++ b/comrade/lib/discord_utils/webhook_tricks.py
@@ -51,7 +51,7 @@ async def get_channel_webhook(channel: GuildText) -> Webhook:
 
 async def send_channel_webhook(
     channel: GuildText, username: str, avatar_url: str, **kwargs
-) -> Message:
+) -> Message | None:
     """
     Send a message as a webhook using a different username and avatar.
 
@@ -68,7 +68,7 @@ async def send_channel_webhook(
 
     Returns
     -------
-    interactions.Message
+    interactions.Message | None
         The message sent.
     """
     webhook = await get_channel_webhook(channel)

--- a/comrade/lib/nhentai/element_parser.py
+++ b/comrade/lib/nhentai/element_parser.py
@@ -1,3 +1,5 @@
+from re import Match
+
 import bs4
 
 from comrade.lib.nhentai.regex import (
@@ -24,7 +26,11 @@ def get_gallery_id_from_cover_block(block: bs4.Tag) -> int:
         The gallery ID.
     """
     cover_a = block.find("a")
-    gallery_id = int(GALLERY_ID_REGEX.search(cover_a["href"]).group(1))
+    search_result = GALLERY_ID_REGEX.search(cover_a["href"])
+    if not isinstance(search_result, Match):
+        raise ValueError("Could not determine gallery ID from cover block")
+
+    gallery_id = int(search_result.group(1))
 
     return gallery_id
 
@@ -46,7 +52,10 @@ def get_images_id_from_noscript_block(block: bs4.Tag) -> int:
     int
         The images ID.
     """
-    images_id = int(IMAGES_ID_REGEX.search(str(block)).group(1))
+    search_result = IMAGES_ID_REGEX.search(str(block))
+    if not isinstance(search_result, Match):
+        raise ValueError("Could not determine images ID from noscript block")
+    images_id = int(search_result.group(1))
 
     return images_id
 
@@ -126,7 +135,9 @@ def get_gallery_id_and_title_from_gallery_div(
 
     # Find the <div> tag with the title
     title_div = gallery_div.find("div", class_="caption")
-    return (
-        int(GALLERY_ID_REGEX.search(gallery_a["href"]).group(1)),
-        title_div.text,
-    )
+
+    search_result = GALLERY_ID_REGEX.search(gallery_a["href"])
+    if not isinstance(search_result, Match):
+        raise ValueError("Could not determine gallery ID from gallery div")
+
+    return (int(search_result.group(1)), title_div.text)

--- a/comrade/modules/booru_cmds.py
+++ b/comrade/modules/booru_cmds.py
@@ -78,7 +78,7 @@ class Booru(Extension):
 
         await ctx.send(
             embed=booru_session.formatted_embed,
-            components=[self.next_page_button],
+            components=[self.next_post_button],
         )
 
     @booru.autocomplete("tags")
@@ -123,19 +123,19 @@ class Booru(Extension):
             del self.booru_sessions[ctx]
             return
         await ctx.send(
-            embed=session.formatted_embed, components=[self.next_page_button]
+            embed=session.formatted_embed,
+            components=[self.next_post_button],
         )
 
     @property
-    def next_page_button(self, disabled: bool = False):
+    def next_post_button(self):
         """
-        Button used to advance pages in an nhentai gallery.
+        Button used to advance pages in a booru session.
         """
         return Button(
             style=ButtonStyle.PRIMARY,
             label="Next Post",
             custom_id="booru_next",
-            disabled=disabled,
         )
 
     @listen("message_create")

--- a/comrade/modules/nhentai_cmds/base.py
+++ b/comrade/modules/nhentai_cmds/base.py
@@ -1,3 +1,8 @@
+from interactions import (
+    Button,
+    ButtonStyle,
+)
+
 from comrade.core.bot_subclass import Comrade
 from comrade.lib.discord_utils import ContextDict
 from comrade.lib.nhentai.structures import (
@@ -10,3 +15,27 @@ class NHBase:
     bot: Comrade
     gallery_sessions: ContextDict[NHentaiGallerySession] = ContextDict()
     search_sessions: ContextDict[NHentaiSearchSession] = ContextDict()
+
+    def next_page_button(self, disabled: bool = False):
+        """
+        Button used to advance pages in an nhentai gallery.
+        """
+        return Button(
+            style=ButtonStyle.PRIMARY,
+            label="Next",
+            custom_id="nhentai_np",
+            disabled=disabled,
+            emoji="➡️",
+        )
+
+    def prev_page_button(self, disabled: bool = False):
+        """
+        Button used to go back a page in an nhentai gallery.
+        """
+        return Button(
+            style=ButtonStyle.PRIMARY,
+            label="Previous",
+            custom_id="nhentai_pp",
+            disabled=disabled,
+            emoji="⬅️",
+        )

--- a/comrade/modules/nhentai_cmds/cacher.py
+++ b/comrade/modules/nhentai_cmds/cacher.py
@@ -11,41 +11,60 @@ class NHCacher(NHBase):
     async def preemptive_cache(
         self,
         session: NHentaiGallerySession,
-        lookahead: int,
-    ) -> list[int]:
+        lookback: int = 0,
+        lookahead: int = 0,
+    ) -> tuple[list[int], list[int]]:
         """
-        Preemptively caches the next few pages of
+        Preemptively caches the next few/previous pages of
         the gallery session.
 
         Parameters
         ----------
         session: NHentaiGallerySession
             The gallery session
+        lookback: int
+            The number of pages to cache before the current page
         lookahead: int
-            The number of pages to cache ahead of the current page
+            The number of pages to cache after the current page
 
         Notes
         -----
-        Fails silently if the page is already cached,
+        Fails silently if the pages are already cached,
         or if the page is not found.
 
         Returns
         -------
         list[int]
-            List of page numbers that were cached.
+            List of page numbers that were newly cached.
+        list[int]
+            List of page numbers that were already cached.
 
         """
         curr_page_num = session.current_page_number
 
         nums_cached = []
+        nums_loaded = []
 
-        for page_num in range(curr_page_num + 1, curr_page_num + lookahead + 1):
-            if not session.is_valid_page_number(page_num):
+        pages_to_cache = range(
+            curr_page_num - lookback, curr_page_num + 1 + lookahead
+        )
+
+        for page_num in pages_to_cache:
+            if (
+                not session.is_valid_page_number(page_num)
+                or page_num == curr_page_num
+            ):
                 continue
 
             page_url = session.page_url(page_num)
             page_filename = session.page_filename(page_num)
 
+            # check if the page is already cached
+            if await self.bot.relay.find_blob_by_url(page_url):
+                nums_loaded.append(page_num)
+                continue
+
+            # otherwise, cache it
             try:
                 await self.bot.relay.create_blob_from_url(
                     source_url=page_url, filename=page_filename
@@ -58,4 +77,5 @@ class NHCacher(NHBase):
                     f"for gallery {session.gallery.gallery_id}"
                 )
                 pass
-        return nums_cached
+
+        return nums_cached, nums_loaded

--- a/comrade/modules/nhentai_cmds/commands_main.py
+++ b/comrade/modules/nhentai_cmds/commands_main.py
@@ -24,7 +24,7 @@ from comrade.lib.nhentai.structures import (
     NHentaiSortOrder,
 )
 
-from .page_handler import NHPageHandler, PrefetchStrategy
+from .page_handler import NHPageHandler, PageDirection, PrefetchStrategy
 from .search_cmds import NHSearchHandler
 
 
@@ -182,7 +182,7 @@ class NHentai(Extension, NHSearchHandler, NHPageHandler):
                     # Locate the session
                     nh_gallery_session = self.gallery_sessions[ctx]
                     await self.handle_nhentai_change_page(
-                        ctx, nh_gallery_session, "next"
+                        ctx, nh_gallery_session, PageDirection.NEXT
                     )
 
                 except KeyError:

--- a/comrade/modules/nhentai_cmds/commands_main.py
+++ b/comrade/modules/nhentai_cmds/commands_main.py
@@ -24,7 +24,7 @@ from comrade.lib.nhentai.structures import (
     NHentaiSortOrder,
 )
 
-from .page_handler import NHPageHandler
+from .page_handler import NHPageHandler, PrefetchStrategy
 from .search_cmds import NHSearchHandler
 
 
@@ -103,7 +103,9 @@ class NHentai(Extension, NHSearchHandler, NHPageHandler):
             )
             return
 
-        await self.send_current_gallery_page(ctx, session)
+        await self.send_current_gallery_page(
+            ctx, session, prefetch_strategy=PrefetchStrategy.BOTH
+        )
 
     @slash_command(
         name="nhentai",
@@ -168,6 +170,8 @@ class NHentai(Extension, NHSearchHandler, NHPageHandler):
     async def nhentai_listener(self, message_event: MessageCreate):
         """
         Listens for "np" in channels where a gallery session is active.
+
+        TODO: maybe remove this and just use button navigation?
         """
         message: Message = message_event.message
 
@@ -177,7 +181,9 @@ class NHentai(Extension, NHSearchHandler, NHPageHandler):
                     ctx = PrefixedContext.from_message(self.bot, message)
                     # Locate the session
                     nh_gallery_session = self.gallery_sessions[ctx]
-                    await self.handle_nhentai_next_page(ctx, nh_gallery_session)
+                    await self.handle_nhentai_change_page(
+                        ctx, nh_gallery_session, "next"
+                    )
 
                 except KeyError:
                     # No session active

--- a/comrade/modules/nhentai_cmds/gallery_init.py
+++ b/comrade/modules/nhentai_cmds/gallery_init.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from interactions import (
     SlashContext,
 )
@@ -48,10 +50,13 @@ class NHGalleryInit(NHCacher):
 
         await ctx.send(
             embed=nh_gallery.start_embed,
-            content="Type `np` (or click the button) to"
+            content="Type `np` (or click the buttons) to"
             " start reading, and advance pages.",
-            components=[self.next_page_button],
+            components=[
+                self.prev_page_button(disabled=True),
+                self.next_page_button(),
+            ],
         )
 
-        # preemptively cache the next few pages
-        await self.preemptive_cache(session, lookahead=3)
+        # preemptively cache the next few pages (nonblocking)
+        asyncio.create_task(self.preemptive_cache(session, lookahead=3))

--- a/comrade/modules/voice_recorder.py
+++ b/comrade/modules/voice_recorder.py
@@ -7,14 +7,19 @@ from interactions import (
     File,
     OptionType,
     SlashContext,
+    User,
     slash_command,
     slash_option,
 )
 from pydub import AudioSegment
 
+from comrade.core.bot_subclass import Comrade
+
 
 class VoiceRecorder(Extension):
-    @slash_command(description="record some audio")
+    bot: Comrade
+
+    @slash_command(description="record some audio", dm_permission=False)
     @slash_option(
         name="duration",
         description="duration to record for (seconds)",
@@ -24,6 +29,10 @@ class VoiceRecorder(Extension):
         max_value=30,
     )
     async def record(self, ctx: SlashContext, duration: int):
+        if isinstance(ctx.author, User):
+            # This should never happen, but just in case
+            await ctx.send("This command can only be used in a server.")
+
         voice_state = await ctx.author.voice.channel.connect()
 
         # Start recording

--- a/tests/modules/test_nhentai_gallery.py
+++ b/tests/modules/test_nhentai_gallery.py
@@ -42,6 +42,7 @@ async def test_gallery_next_page(ctx: BaseContext):
     msg_event: MessageCreate = await ctx.bot.wait_for(
         "message_create",
         checks=lambda e: e.message.author == ctx.author and e.message.embeds,
+        timeout=10,
     )
     embed = msg_event.message.embeds[0]
 
@@ -54,7 +55,9 @@ async def test_gallery_next_page(ctx: BaseContext):
 
     await ctx.send("np")
     msg_event: MessageCreate = await ctx.bot.wait_for(
-        "message_create", checks=lambda e: e.message.author == ctx.author
+        "message_create",
+        checks=lambda e: e.message.author == ctx.author,
+        timeout=10,
     )
 
     assert msg_event.message.content == "You have reached the end of this work."

--- a/tests/modules/test_nhentai_gallery.py
+++ b/tests/modules/test_nhentai_gallery.py
@@ -21,7 +21,7 @@ async def test_gallery_start(ctx: BaseContext, nhentai_ext: NHentai):
     start_embed_msg = (await ctx.channel.fetch_messages(limit=1))[0]
     assert (
         start_embed_msg.content
-        == "Type `np` (or click the button) to start reading, and advance pages."
+        == "Type `np` (or click the buttons) to start reading, and advance pages."
     )
 
     start_embed = start_embed_msg.embeds[0]
@@ -40,7 +40,8 @@ async def test_gallery_next_page(ctx: BaseContext):
     await ctx.send("np")
 
     msg_event: MessageCreate = await ctx.bot.wait_for(
-        "message_create", checks=lambda e: e.message.author == ctx.author
+        "message_create",
+        checks=lambda e: e.message.author == ctx.author and e.message.embeds,
     )
     embed = msg_event.message.embeds[0]
 

--- a/tests/modules/test_nhentai_search.py
+++ b/tests/modules/test_nhentai_search.py
@@ -59,7 +59,7 @@ async def test_search_click(
     start_embed_msg = (await ctx.channel.fetch_messages(limit=1))[0]
     assert (
         start_embed_msg.content
-        == "Type `np` (or click the button) to start reading, and advance pages."
+        == "Type `np` (or click the buttons) to start reading, and advance pages."
     )
 
     start_embed = start_embed_msg.embeds[0]


### PR DESCRIPTION
Closes #66 

* Preemptive caching now has a direction associated with it
* `send_current_page` allows setting of caching direction
    * next page -> forward caching
    * previous page -> backwards caching
    * gpage -> bi-directional caching
