### PR TITLE
Reminder Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
     
 ![comrade-next-logo](https://user-images.githubusercontent.com/54449457/239707605-5ffae413-a8e7-4f3d-84b9-6100f053b61b.png)
 
-![Discord Bot](https://badgen.net/badge/icon/Discord%20Bot?icon=discord&label=Comrade%20NEXT)
+![Discord Bot](https://badgen.net/badge/icon/Comrade%20NEXT?icon=discord&label=Discord%20Bot)
 [![GitHub tag](https://img.shields.io/github/tag/itchono/comrade-next.svg)](https://github.com/itchono/comrade-next/tags)
-![Python 3.11](https://img.shields.io/badge/Python-3.11+-1081c1?logo=python)
+![Python 3.11](https://img.shields.io/badge/Python-3.10+-1081c1?logo=python)
 ![Code Style: Black](https://img.shields.io/badge/Code%20Style-black-000000.svg)
 
 [![Automated Tests](https://github.com/itchono/comrade-next/actions/workflows/ci-pytest.yml/badge.svg)](https://github.com/itchono/comrade-next/actions/workflows/ci-pytest.yml)

--- a/comrade/lib/booru_ext/structures.py
+++ b/comrade/lib/booru_ext/structures.py
@@ -7,7 +7,7 @@ from orjson import loads
 
 from comrade.lib.booru_ext.const import OPTIONAL_EMBED_FIELDS
 from comrade.lib.booru_ext.filters import clean_up_post_tag
-from comrade.lib.discord_utils.safer_embeds import SafeLengthEmbed
+from comrade.lib.discord_utils import SafeLengthEmbed
 from comrade.lib.text_utils import escape_md
 
 # Create a type alias that can be any of the booru classes

--- a/comrade/lib/discord_utils/__init__.py
+++ b/comrade/lib/discord_utils/__init__.py
@@ -1,5 +1,6 @@
 from .ctx_tricks import ContextDict, context_id, messageable_from_context_id
 from .custom_paginators import DynamicPaginator
+from .safer_embeds import SafeLengthEmbed
 from .webhook_tricks import echo, send_channel_webhook
 
 __all__ = [
@@ -9,4 +10,5 @@ __all__ = [
     "echo",
     "send_channel_webhook",
     "messageable_from_context_id",
+    "SafeLengthEmbed",
 ]

--- a/scripts/migration/reminders_migration.py
+++ b/scripts/migration/reminders_migration.py
@@ -1,0 +1,110 @@
+"""
+Script used to migrade Comrade V5 reminders to V7.
+
+This only needs to be run once. I anticipate that I will be
+the only one who needs to run this script.
+"""
+from argparse import ArgumentParser
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+
+from bson import ObjectId
+from decouple import config
+from pymongo import MongoClient
+
+from comrade.lib.reminders import Reminder
+
+# MongoDB URIs
+PROD_MONOGDB_URI: str = config("MIGRATION_PROD_MONGODB_URI")
+TEST_MONGODB_URI: str = config("MIGRATION_TEST_MONGODB_URI")
+
+
+@dataclass
+class ReminderV5:
+    _id: ObjectId
+    server: bool  # whether the reminder was made in a guild
+    message: str
+    time: datetime  # naive; but the timezone is always UTC when retrieved from the database
+    user: int  # user ID
+    channel: int  # channel ID
+    jumpurl: str  # jump URL to the message
+
+    @classmethod
+    def from_dict(cls, **data):
+        reminder = cls(**data)
+
+        # if the datetimes are naive, make them aware (UTC)
+        if reminder.time.tzinfo is None:
+            reminder.time = reminder.time.replace(tzinfo=timezone.utc)
+        return reminder
+
+    @property
+    def as_reminder_v7(self) -> Reminder:
+        """
+        Converts the reminder to a Reminder object.
+        """
+        # the key missing field is the guild ID, which we must manually patch in
+        # We can infer this from the jump url
+
+        # format is https://discord.com/channels/{guild_id}/{channel_id}/{message_id}
+
+        if not self.server:
+            guild_id = None
+        else:
+            guild_id = int(self.jumpurl.split("/")[4])
+
+        return Reminder(
+            scheduled_time=self.time,
+            context_id=self.channel if self.server else self.user,
+            author_id=self.user,
+            guild_id=guild_id,
+            note=self.message,
+            jump_url=self.jumpurl,
+            _id=self._id,
+        )
+
+
+def main(run_real: bool = False, wipe_dest: bool = False):
+    db_prod = MongoClient(PROD_MONOGDB_URI)["Comrade"]
+    db_test = MongoClient(TEST_MONGODB_URI)["comradeDB"]
+
+    reminders_v5 = db_prod.Reminders
+
+    if run_real:
+        print("***** RUNNING ON REAL DATABASE *****")
+        input("Press enter to continue...")
+        print("Proceeding with migration")
+        reminders_v7 = db_prod.remindersV7
+    else:
+        reminders_v7 = db_test.remindersV7
+
+    if wipe_dest:
+        print("***** WIPING DESTINATION COLLECTION *****")
+        input("Press enter to continue...")
+        print("Wiping destination collection")
+        reminders_v7.delete_many({})
+
+    for reminder_v5_doc in reminders_v5.find():
+        reminder_v5 = ReminderV5.from_dict(**reminder_v5_doc)
+        print(f"Processing reminder {reminder_v5._id}")
+
+        reminder_v7 = reminder_v5.as_reminder_v7
+        insert_result = reminders_v7.insert_one(asdict(reminder_v7))
+        print(f"Inserted reminder {insert_result.inserted_id}")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--real",
+        action="store_true",
+        help="Whether to run the migration on the real database.",
+    )
+    parser.add_argument(
+        "--wipe_dest",
+        action="store_true",
+        help="Whether to wipe the destination reminder collection before running the migration.",
+    )
+    args = parser.parse_args()
+
+    main(run_real=args.real, wipe_dest=args.wipe_dest)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,16 @@ def event_loop():
     with suppress(asyncio.CancelledError):
         # try to finish all pending tasks
         pending_tasks = asyncio.all_tasks(loop=loop)
-        loop.run_until_complete(asyncio.gather(*pending_tasks))
+
+        # NOTE: reminder tasks loaded by the bot will be pending for a long time
+        # so we need to cancel them manually
+
+        if pending_tasks:
+            # give the tasks a timeout of 30 seconds
+            # to finish before we cancel them
+            futures = asyncio.wait(pending_tasks, timeout=30)
+
+            loop.run_until_complete(futures)
 
     loop.close()
 

--- a/tests/core/test_relay.py
+++ b/tests/core/test_relay.py
@@ -84,7 +84,7 @@ async def test_update_hook_perform_update(
     """
     stored_args = []
 
-    dummy_msg = SimpleNamespace()
+    dummy_msg = SimpleNamespace(channel=channel)
 
     with monkeypatch.context() as m:
 
@@ -99,7 +99,6 @@ async def test_update_hook_perform_update(
 
         # IMPORTANT: PREVENT THE BOT FROM ACTUALLY STOPPING
         m.setattr(bot, "stop", bot_stop)
-        m.setattr(dummy_msg, "channel", channel, raising=False)
 
         await perform_update(dummy_msg, bot)
 

--- a/tests/lib/test_du_safer_embeds.py
+++ b/tests/lib/test_du_safer_embeds.py
@@ -1,6 +1,6 @@
 from interactions import Embed
 
-from comrade.lib.discord_utils.safer_embeds import SafeLengthEmbed
+from comrade.lib.discord_utils import SafeLengthEmbed
 
 
 def test_embed_nominal():

--- a/tests/lib/test_reminder.py
+++ b/tests/lib/test_reminder.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
 from comrade.lib.reminders import Reminder
@@ -11,7 +12,7 @@ def test_reminder_expiry_positive():
 
     reminder_time = now + negative_delta
 
-    reminder = Reminder(reminder_time, now, 1, 1, 1, "test", "test")
+    reminder = Reminder(reminder_time, 1, 1, 1, "test", "test")
 
     assert reminder.expired is True
 
@@ -22,7 +23,7 @@ def test_reminder_expiry_negative():
 
     reminder_time = now + positive_delta
 
-    reminder = Reminder(reminder_time, now, 1, 1, 1, "test", "test")
+    reminder = Reminder(reminder_time, 1, 1, 1, "test", "test")
 
     assert reminder.expired is False
 
@@ -33,7 +34,7 @@ def test_reminder_naive_timestamp():
 
     reminder_time = now + positive_delta
 
-    reminder = Reminder(reminder_time, now, 1, 1, 1, "test", "test")
+    reminder = Reminder(reminder_time, 1, 1, 1, "test", "test")
 
     local_tz = datetime.now().astimezone().tzinfo
 
@@ -79,3 +80,17 @@ def test_reminder_alternate_timezone():
     assert (
         reminder.naive_scheduled_time - naive_now_plus_1s
     ).total_seconds() < 1
+
+
+def test_reminder_jump_url_nominal():
+    fake_reminder = SimpleNamespace(
+        jump_url="https://discord.com/channels/0000001/00000000/12345678"
+    )
+
+    assert Reminder.reply_id.__get__(fake_reminder) == 12345678
+
+
+def test_reminder_jump_url_null():
+    fake_reminder = SimpleNamespace(jump_url=None)
+
+    assert Reminder.reply_id.__get__(fake_reminder) is None


### PR DESCRIPTION
This PR adds a migration script for V5 -> V7 reminder migration (closes #45 )

It also makes some optimizations and improvements to the reminders system
* elimination of `creation_time` attr -- this is captured in the `_id` field already thanks to the BSON objectid
* `_id` field is created by default when `Reminder` is instantiated, with an ObjectID
* made the process for starting reminders a little smoother
* slash command-invoked reminders now have a jump url (hacky)